### PR TITLE
docs: link to diagram

### DIFF
--- a/.docs/content/0.armonik/0.index.md
+++ b/.docs/content/0.armonik/0.index.md
@@ -8,6 +8,8 @@ It provides a reference architecture that can be used to build and adapt a moder
 This project is an Open Source ([Apache 2.0 License](https://github.com/aneoconsulting/ArmoniK/blob/main/LICENSE)).
 ::
 
+Here is an overview of how Armonik works:
+![Armonik overview diagram](/architecture-ArmoniK-internals.svg)
 ## When should I use ArmoniK
 
 ArmoniK should be used when the following criteria are met:


### PR DESCRIPTION
adding a link to display ArmoniK's architecture diagram